### PR TITLE
feat: add environment scoped secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ ev load .env
 <sup>All the variables on `.env` will be loaded into the default environment</sup>
 </details>
 
+<details>
+  <summary><strong>Setting a different secret for specific environments →</strong></summary>
+<br>
+When using this tool, you may want to give access to staging/local environment variables but not to the production ones.
+
+```bash
+ev change-secret -e production
+```
+<sup>Changes the default secret on the <code>production</code> environment</sup>
+</details>
+
 ## Using in your project
 After initializing and setting a secret, you can just load from your previous `.env` file with the command `ev load .env` and run either `ev | source` or `eval $(ev)` to export the variables into the environment.
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -54,29 +54,29 @@ export const saveVariablesToFile = (variables: any, secret: Buffer, environment?
     fs.writeFileSync(filePath, encryptedContent)
 }
 
-export const loadSecretFromFile = async() => {
-    const filePath = getFilePath('secret')
+export const loadSecretFromFile = async(environment?: string) => {
+    const filePath = getFilePath(environment ? `${environment}.secret` : 'secret')
     fse.ensureFileSync(filePath)
 
     const secret = fs.readFileSync(filePath)
     
     if (secret.length === 0) {
         const newSecret = await promptSecret('Enter a new secret')
-        return saveSecretToFile(newSecret)
+        return saveSecretToFile(newSecret, environment)
     }
     
     return secret
 }
 
-export const saveSecretToFile = (secret: string) => {
-    const filePath = getFilePath('secret')
+export const saveSecretToFile = (secret: string, environment?: string) => {
+    const filePath = getFilePath(environment ? `${environment}.secret` : 'secret')
     fse.ensureFileSync(filePath)
     
     const secretKey = getKeyFromSecret(Buffer.from(secret, 'utf8'))
     fs.writeFileSync(filePath, secretKey)
 
     const gitIgnoreFilePath = getFilePath('.gitignore')
-    fs.writeFileSync(gitIgnoreFilePath, 'secret')
+    fs.writeFileSync(gitIgnoreFilePath, '*secret')
 
     return secretKey
 }


### PR DESCRIPTION
# what
- Added environment support to `change-secret` and `set-secret` commands

# why
It enables developers to scope access to different environments, which may prove useful in production workloads, with secrets embedded directly into its' container through environment variables. 